### PR TITLE
Add interaction urgency heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ We are releasing *TinyTroupe* at a relatively early stage, with considerable wor
 
 
 ## LATEST NEWS
+**[2025-02-02] Pequena atualização:**
+  - Nova heurística de urgência de interação. `TinyWorld` só aciona agentes quando a urgência é maior que `URGENCY_TO_ACT_THRESHOLD`.
 **[2025-01-29] Release 0.4.0 with various improvements. Some highlights:**
   - Personas have deeper specifications now, including  personality traits, preferences, beliefs, and more. It is likely we'll further expand this in the future. 
   - `TinyPerson`s can now be defined as JSON files as well, and loaded via the `TinyPerson.load_specification()`, for greater convenience. After loading the JSON file, you can still modify the agent programmatically. See the [examples/agents/](./examples/agents/) folder for examples.

--- a/tinytroupe/agent/tiny_person.py
+++ b/tinytroupe/agent/tiny_person.py
@@ -1208,6 +1208,44 @@ class TinyPerson(JsonSerializableRegistry):
         else:
             return None
 
+    def _calculate_interaction_urgency(self, observation: str,
+                                        relevance_threshold: float = 0.5,
+                                        mention_urgency: float = 9.0) -> float:
+        """Calcula a urgência de interação dado uma observação."""
+
+        try:
+            if self.name.lower() in observation.lower():
+                return float(mention_urgency)
+
+            def _cosine_similarity(v1, v2):
+                import math
+                dot = sum(a * b for a, b in zip(v1, v2))
+                norm1 = math.sqrt(sum(a * a for a in v1))
+                norm2 = math.sqrt(sum(b * b for b in v2))
+                if norm1 == 0 or norm2 == 0:
+                    return 0.0
+                return dot / (norm1 * norm2)
+
+            status_text = getattr(self, "status", json.dumps(self._mental_state))
+            status_emb = openai_utils.client().get_embedding(status_text)
+            obs_emb = openai_utils.client().get_embedding(observation)
+            similarity = _cosine_similarity(status_emb, obs_emb)
+            if similarity < relevance_threshold:
+                return 1.0
+
+            llm_request = openai_utils.LLMRequest(
+                system_prompt="Você analisa uma observação e estima a urgência de interação (1 a 10).",
+                user_prompt=f"Observação: {observation}\nResponda somente com um número entre 1 e 10.",
+                output_type=float,
+                temperature=0.0,
+                max_tokens=5,
+            )
+            return float(llm_request.call())
+
+        except Exception as e:
+            logger.error(f"[{self.name}] Erro ao calcular urgência: {e}")
+            return 2.0
+
     ###########################################################
     # IO
     ###########################################################

--- a/tinytroupe/environment/tiny_world.py
+++ b/tinytroupe/environment/tiny_world.py
@@ -6,6 +6,7 @@ import textwrap
 
 from tinytroupe.agent import *
 from tinytroupe.utils import name_or_empty, pretty_datetime
+import json
 import tinytroupe.control as control
 from tinytroupe.control import transactional
 from tinytroupe import utils
@@ -25,6 +26,9 @@ class TinyWorld:
 
     # Whether to display environments communications or not, for all environments. 
     communication_display = True
+
+    # Urgência mínima para que um agente aja
+    URGENCY_TO_ACT_THRESHOLD = 5.0
 
     def __init__(self, name: str="A TinyWorld", agents=[], 
                  initial_datetime=datetime.now(),
@@ -100,10 +104,20 @@ class TinyWorld:
         agents_actions = {}
         for agent in self.agents:
             logger.debug(f"[{self.name}] Agent {name_or_empty(agent)} is acting.")
-            actions = agent.act(return_actions=True)
+
+            last_mem = agent.episodic_memory.retrieve_last(1, include_omission_info=False)
+            observation = json.dumps(last_mem[-1]["content"]) if last_mem else ""
+            urgency = agent._calculate_interaction_urgency(observation)
+
+            if urgency >= TinyWorld.URGENCY_TO_ACT_THRESHOLD:
+                actions = agent.act(return_actions=True)
+            else:
+                actions = []
+
             agents_actions[agent.name] = actions
 
-            self._handle_actions(agent, agent.pop_latest_actions())
+            if actions:
+                self._handle_actions(agent, agent.pop_latest_actions())
         
         return agents_actions
         


### PR DESCRIPTION
## Summary
- estimate urgency for interactions in TinyPerson
- use urgency threshold when stepping TinyWorld
- document urgency feature

## Testing
- `pip install -e .`
- `pytest -q` *(fails: OpenAIError)*

------
https://chatgpt.com/codex/tasks/task_e_68504d1c4cbc832b8797f69ccfc588cc